### PR TITLE
Support range headers with an end range past EOF

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,16 +85,16 @@ mod macros;
 /// syntactically correct ranges actually makes sense in context
 ///
 /// The range `bytes=0-20` on a file with 15 bytes will be accepted in the first pass as the content_size is unknown.
-/// On the second pass (`validate`) it will be rejected and produce an error
-/// # Example range fails `validate` because it exceedes file boundaries
+/// On the second pass (`validate`) it will be truncated to `file_size - 1` as per [the spec](https://httpwg.org/specs/rfc9110.html#rfc.section.14.1.2).
+/// # Example range truncates in `validate` because it exceedes
 /// ```
 /// let input = "bytes=0-20";
 /// let file_size_bytes = 15;
 /// let parsed_ranges = http_range_header::parse_range_header(input)
 ///     // Is syntactically correct
 ///     .unwrap();
-/// let validated = parsed_ranges.validate(file_size_bytes);
-/// assert!(validated.is_err());
+/// let validated = parsed_ranges.validate(file_size_bytes).unwrap();
+/// assert_eq!(vec![0..=14], validated);
 /// ```
 ///
 /// Range reversal and overlap is also checked in the second pass, the range `bytes=0-20, 5-10`


### PR DESCRIPTION
As discussed in #2 

This is specified in section 14.1.2 of the httpwg rfc9110 (https://httpwg.org/specs/rfc9110.html#rfc.section.14.1.2), and section 14.35.1 of the ietf rfc2616 linked in this repo:

"A client can limit the number of bytes requested without knowing the size of the selected representation. If the last-pos value is absent, or if the value is greater than or equal to the current length of the representation data, the byte range is interpreted as the remainder of the representation (i.e., the server replaces the value of last-pos with a value that is one less than the current length of the selected representation)."

rfc2616 has different wording, but is essentially the same.