### PR TITLE
Cleanup, lint, fmt, dev dep update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-range-header"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 license = "MIT"
 readme = "./README.md"
@@ -10,6 +10,7 @@ homepage = "https://github.com/MarcusGrass/parse-range-headers"
 categories = ["parser-implementations", "network-programming", "web-programming"]
 keywords = ["http", "parser", "http-headers", "headers", "range"]
 exclude = ["/.github", "CONTRIBUTING.md"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 with_error_cause = []
@@ -17,10 +18,10 @@ with_error_cause = []
 [dependencies]
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = "0.5.1"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-regex = "1.5.4"
+regex = "1.8.3"
 
 [[bench]]
 name = "benchmark"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,46 @@
-# 0.1.0
-Released first version under parse_range_headers
+<!-- markdownlint-disable blanks-around-headings blanks-around-lists no-duplicate-heading -->
 
-# 0.2.0
-Rename to http-range-header
+# Changelog
 
-# 0.2.1
-Make some optimization
+All notable changes to this project will be documented in this file.
 
-# 0.2.2 
-Fix a bug where single reversed range headers were erroneously passing validation
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# 0.3.0 
-Only expose a single error-type to make usage more ergonomic
+<!-- next-header -->
+## [Unreleased] - ReleaseDate
+### Added
+### Changed
+### Fixed
+
+## [0.3.1] - 2023-07-21
+
+### Fixed
+- Now accepts ranges that are out of bounds, but truncates them down to an in-range 
+value, according to the spec, thanks @jfaust!
+- Clean up with clippy pedantic, update docs, format, etc. Resulted in a bench improvement of almost
+5%.
+
+## [0.3.0] - 2021-11-25
+
+### Changed
+
+- Only expose a single error-type to make usage more ergonomic
+
+## [0.2.1] - 2021-11-25
+
+### Added
+
+- Make some optimizations
+
+## [0.2.0] - 2021-11-25
+
+### Changed
+
+- Rename to http-range-header
+
+## [0.1.0] - 2021-11-25
+
+### Added
+
+- Released first version under parse_range_headers


### PR DESCRIPTION
Change changelog to a proper format, update for linting, update dev deps. 
Just changing the string `starts_with` from f.e. `"+"` to `'+'` resulted in a measured bench speed increase of about 5% across tests, which is nice